### PR TITLE
[FEAT] 마지막 챌린지 조회 쿼리 추가

### DIFF
--- a/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
+++ b/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
@@ -14,7 +14,7 @@ interface ChallengeDao {
     fun insertChallenge(challengeEntity: ChallengeEntity)
 
     @Query("SELECT * FROM challenge ORDER BY date DESC LIMIT 1")
-    fun getLastChallenge(): ChallengeEntity?
+    suspend fun getLastChallenge(): ChallengeEntity?
 
     @Query("SELECT * FROM challenge ORDER BY date DESC")
     fun getChallengesFlow(): PagingSource<Int, ChallengeEntity>

--- a/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
+++ b/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
@@ -13,9 +13,6 @@ interface ChallengeDao {
     @Insert
     fun insertChallenge(challengeEntity: ChallengeEntity)
 
-    @Query("SELECT * FROM challenge ORDER BY date DESC")
-    fun getChallenges(): List<ChallengeEntity>
-
     @Query("SELECT * FROM challenge ORDER BY date DESC LIMIT 1")
     fun getLastChallenge(): ChallengeEntity?
 

--- a/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
+++ b/app/src/main/java/com/hrhn/data/local/dao/ChallengeDao.kt
@@ -16,6 +16,9 @@ interface ChallengeDao {
     @Query("SELECT * FROM challenge ORDER BY date DESC")
     fun getChallenges(): List<ChallengeEntity>
 
+    @Query("SELECT * FROM challenge ORDER BY date DESC LIMIT 1")
+    fun getLastChallenge(): ChallengeEntity?
+
     @Query("SELECT * FROM challenge ORDER BY date DESC")
     fun getChallengesFlow(): PagingSource<Int, ChallengeEntity>
 

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 interface ChallengeDataSource {
     val challengesFlow: Flow<PagingData<Challenge>>
     fun insertChallenge(challenge: Challenge)
-    fun getChallenges(): List<Challenge>
     fun getLastChallenge(): Challenge?
     fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): List<Challenge>
     fun updateChallenge(challenge: Challenge)

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
@@ -9,6 +9,7 @@ interface ChallengeDataSource {
     val challengesFlow: Flow<PagingData<Challenge>>
     fun insertChallenge(challenge: Challenge)
     fun getChallenges(): List<Challenge>
+    fun getLastChallenge(): Challenge?
     fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): List<Challenge>
     fun updateChallenge(challenge: Challenge)
     fun deleteChallenge(id: Long)

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSource.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 interface ChallengeDataSource {
     val challengesFlow: Flow<PagingData<Challenge>>
     fun insertChallenge(challenge: Challenge)
-    fun getLastChallenge(): Challenge?
+    suspend fun getLastChallenge(): Challenge?
     fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): List<Challenge>
     fun updateChallenge(challenge: Challenge)
     fun deleteChallenge(id: Long)

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
@@ -30,6 +30,10 @@ class ChallengeDataSourceImpl @Inject constructor(
         return challengeDao.getChallenges().map { it.toModel() }
     }
 
+    override fun getLastChallenge(): Challenge? {
+        return challengeDao.getLastChallenge()?.toModel()
+    }
+
     override fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): List<Challenge> {
         return challengeDao.getChallengesWithPeriod(from, to).map { it.toModel() }
     }

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
@@ -26,10 +26,6 @@ class ChallengeDataSourceImpl @Inject constructor(
         challengeDao.insertChallenge(challenge.toEntity())
     }
 
-    override fun getChallenges(): List<Challenge> {
-        return challengeDao.getChallenges().map { it.toModel() }
-    }
-
     override fun getLastChallenge(): Challenge? {
         return challengeDao.getLastChallenge()?.toModel()
     }

--- a/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
+++ b/app/src/main/java/com/hrhn/data/local/source/ChallengeDataSourceImpl.kt
@@ -26,7 +26,7 @@ class ChallengeDataSourceImpl @Inject constructor(
         challengeDao.insertChallenge(challenge.toEntity())
     }
 
-    override fun getLastChallenge(): Challenge? {
+    override suspend fun getLastChallenge(): Challenge? {
         return challengeDao.getLastChallenge()?.toModel()
     }
 

--- a/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
+++ b/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
@@ -20,10 +20,6 @@ class ChallengeRepositoryImpl @Inject constructor(
         return runCatching { challengeDataSource.insertChallenge(challenge) }
     }
 
-    override fun getChallenges(): Result<List<Challenge>> {
-        return runCatching { challengeDataSource.getChallenges() }
-    }
-
     override fun getChallengesWithPeriod(
         from: LocalDateTime,
         to: LocalDateTime
@@ -32,7 +28,7 @@ class ChallengeRepositoryImpl @Inject constructor(
     }
 
     override fun getLastChallenge(): Result<Challenge?> {
-        return runCatching { challengeDataSource.getChallenges().getOrNull(0) }
+        return runCatching { challengeDataSource.getLastChallenge() }
     }
 
     override fun updateChallenge(challenge: Challenge): Result<Unit> {

--- a/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
+++ b/app/src/main/java/com/hrhn/data/repository/ChallengeRepositoryImpl.kt
@@ -27,7 +27,7 @@ class ChallengeRepositoryImpl @Inject constructor(
         return runCatching { challengeDataSource.getChallengesWithPeriod(from, to) }
     }
 
-    override fun getLastChallenge(): Result<Challenge?> {
+    override suspend fun getLastChallenge(): Result<Challenge?> {
         return runCatching { challengeDataSource.getLastChallenge() }
     }
 

--- a/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
+++ b/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
@@ -9,7 +9,7 @@ interface ChallengeRepository {
     val challengesFlow: Flow<PagingData<Challenge>>
     fun insertChallenge(challenge: Challenge): Result<Unit>
     fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): Result<List<Challenge>>
-    fun getLastChallenge(): Result<Challenge?>
+    suspend fun getLastChallenge(): Result<Challenge?>
     fun updateChallenge(challenge: Challenge): Result<Unit>
     fun deleteChallenge(id: Long): Result<Unit>
 }

--- a/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
+++ b/app/src/main/java/com/hrhn/domain/repository/ChallengeRepository.kt
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 interface ChallengeRepository {
     val challengesFlow: Flow<PagingData<Challenge>>
     fun insertChallenge(challenge: Challenge): Result<Unit>
-    fun getChallenges(): Result<List<Challenge>>
     fun getChallengesWithPeriod(from: LocalDateTime, to: LocalDateTime): Result<List<Challenge>>
     fun getLastChallenge(): Result<Challenge?>
     fun updateChallenge(challenge: Challenge): Result<Unit>

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/CheckChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/CheckChallengeViewModel.kt
@@ -9,7 +9,6 @@ import com.hrhn.domain.repository.ChallengeRepository
 import com.hrhn.presentation.util.Event
 import com.hrhn.presentation.util.emit
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -29,7 +28,7 @@ class CheckChallengeViewModel @Inject constructor(
     val message: LiveData<Event<String>> get() = _message
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             repository.getLastChallenge()
                 .onSuccess {
                     if (it != null && it.date.toLocalDate() == LocalDate.now()) {


### PR DESCRIPTION
## 관련 이슈
- close #56

## 주요 구현 사항
- 마지막 챌린지 조회 쿼리 추가
- suspend 키워드 추가