### PR TITLE
[UI] 챌린지 바구니 메뉴 추가

### DIFF
--- a/app/src/main/java/com/hrhn/presentation/ui/screen/MainActivity.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/MainActivity.kt
@@ -2,18 +2,16 @@ package com.hrhn.presentation.ui.screen
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.commit
 import com.hrhn.R
 import com.hrhn.databinding.ActivityMainBinding
 import com.hrhn.presentation.ui.screen.main.past.PastChallengeFragment
-import com.hrhn.presentation.ui.screen.main.past.PastChallengeViewModel
 import com.hrhn.presentation.ui.screen.main.today.TodayFragment
-import com.hrhn.presentation.ui.screen.main.today.TodayViewModel
 import com.hrhn.presentation.ui.screen.onboarding.OnboardingActivity
 import com.hrhn.presentation.ui.screen.setting.SettingActivity
+import com.hrhn.presentation.ui.screen.storage.StorageFragment
 import com.hrhn.presentation.util.SharedPreferenceManager
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,8 +20,7 @@ class MainActivity : AppCompatActivity() {
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
     private val todayFragment by lazy { TodayFragment() }
     private val pastChallengeFragment by lazy { PastChallengeFragment() }
-    private val todayViewModel by viewModels<TodayViewModel>()
-    private val pastChallengeViewModel by viewModels<PastChallengeViewModel>()
+    private val storageFragment by lazy { StorageFragment() }
     private val sharedPreferenceManager by lazy { SharedPreferenceManager(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,6 +49,11 @@ class MainActivity : AppCompatActivity() {
                 R.id.menu_past_challenge -> {
                     supportFragmentManager.commit {
                         replace(R.id.fcv_main, pastChallengeFragment)
+                    }
+                }
+                R.id.menu_storage -> {
+                    supportFragmentManager.commit {
+                        replace(R.id.fcv_main, storageFragment)
                     }
                 }
             }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
@@ -49,7 +49,7 @@ class AddChallengeFragment : Fragment() {
         with(binding) {
             lifecycleOwner = viewLifecycleOwner
             vm = viewModel
-            etNewChallenge.requestFocus()
+            etNewChallenge.root.requestFocus()
         }
     }
 

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/storage/StorageFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/storage/StorageFragment.kt
@@ -1,0 +1,43 @@
+package com.hrhn.presentation.ui.screen.storage
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.hrhn.databinding.FragmentStorageBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class StorageFragment : Fragment() {
+    private var _binding: FragmentStorageBinding? = null
+    private val binding get() = requireNotNull(_binding)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentStorageBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initViews()
+        observeData()
+    }
+
+    private fun initViews() {
+
+    }
+
+    private fun observeData() {
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/drawable/ic_add_24.xml
+++ b/app/src/main/res/drawable/ic_add_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_close_24.xml
+++ b/app/src/main/res/drawable/ic_close_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_folder_off_48.xml
+++ b/app/src/main/res/drawable/ic_folder_off_48.xml
@@ -1,0 +1,6 @@
+<vector android:height="48dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,6h-8l-2,-2H7.17l4,4H20v9.17l1.76,1.76C21.91,18.65 22,18.34 22,18V8C22,6.9 21.1,6 20,6z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M2.1,2.1L0.69,3.51l1.56,1.56C2.1,5.35 2.01,5.66 2.01,6L2,18c0,1.1 0.9,2 2,2h13.17l3.31,3.31l1.41,-1.41L2.1,2.1zM4,18V6.83L15.17,18H4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_inventory_2_24.xml
+++ b/app/src/main/res/drawable/ic_inventory_2_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,2H4C3,2 2,2.9 2,4v3.01C2,7.73 2.43,8.35 3,8.7V20c0,1.1 1.1,2 2,2h14c0.9,0 2,-0.9 2,-2V8.7c0.57,-0.35 1,-0.97 1,-1.69V4C22,2.9 21,2 20,2zM15,14H9v-2h6V14zM20,7H4V4h16V7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_outline_inventory_2_24.xml
+++ b/app/src/main/res/drawable/ic_outline_inventory_2_24.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,2H4C3,2 2,2.9 2,4v3.01C2,7.73 2.43,8.35 3,8.7V20c0,1.1 1.1,2 2,2h14c0.9,0 2,-0.9 2,-2V8.7c0.57,-0.35 1,-0.97 1,-1.69V4C22,2.9 21,2 20,2zM19,20H5V9h14V20zM20,7H4V4h16V7z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M9,12h6v2h-6z"/>
+</vector>

--- a/app/src/main/res/drawable/selector_storage.xml
+++ b/app/src/main/res/drawable/selector_storage.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_outline_inventory_2_24" android:state_checked="false" />
+    <item android:drawable="@drawable/ic_inventory_2_24" android:state_checked="true" />
+</selector>

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -21,15 +21,14 @@
             android:layout_marginHorizontal="@dimen/space_default"
             android:text="@string/message_new_challenge"
             android:textAppearance="@style/HeaderText"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:layout_editor_absoluteX="20dp" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <EditText
             android:id="@+id/et_new_challenge"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/space_large"
-            android:layout_marginVertical="@dimen/space_default"
+            android:layout_marginTop="@dimen/space_default"
             android:background="@drawable/bg_challenge_card"
             android:gravity="center"
             android:hint="@string/hint_for_challenge"
@@ -40,10 +39,22 @@
             android:paddingVertical="@dimen/space_default"
             android:text="@={vm.input}"
             android:textColor="@color/cell_label"
-            android:textSize="20sp"
+            android:textSize="@dimen/text_size_body2"
             android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@id/btn_next"
+            app:layout_constraintBottom_toTopOf="@id/btn_storage"
             app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_storage"
+            style="@style/IconTextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/space_small"
+            android:text="바구니"
+            app:icon="@drawable/ic_outline_inventory_2_24"
+            app:layout_constraintBottom_toTopOf="@id/btn_next"
+            app:layout_constraintEnd_toEndOf="@id/et_new_challenge"
+            app:layout_constraintTop_toBottomOf="@id/et_new_challenge" />
 
         <TextView
             android:id="@+id/tv_length"
@@ -52,6 +63,7 @@
             android:gravity="end"
             android:text="@{String.valueOf(vm.input.length())}"
             android:textColor="@color/cell_label"
+            android:textSize="@dimen/text_size_caption"
             android:textStyle="bold"
             app:layout_constraintBaseline_toBaselineOf="@id/tv_max"
             app:layout_constraintEnd_toStartOf="@id/tv_max"
@@ -65,6 +77,7 @@
             android:gravity="end"
             android:text="/50"
             android:textColor="@color/cell_label"
+            android:textSize="@dimen/text_size_caption"
             android:textStyle="bold"
             app:layout_constraintBottom_toBottomOf="@id/et_new_challenge"
             app:layout_constraintEnd_toEndOf="@id/et_new_challenge" />

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -25,22 +25,13 @@
 
         <EditText
             android:id="@+id/et_new_challenge"
+            style="@style/ChallengeInputCard"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/space_large"
             android:layout_marginTop="@dimen/space_default"
-            android:background="@drawable/bg_challenge_card"
-            android:gravity="center"
-            android:hint="@string/hint_for_challenge"
             android:importantForAutofill="no"
-            android:inputType="textMultiLine"
-            android:maxLength="50"
-            android:paddingHorizontal="@dimen/space_large"
-            android:paddingVertical="@dimen/space_default"
             android:text="@={vm.input}"
-            android:textColor="@color/cell_label"
-            android:textSize="@dimen/text_size_body2"
-            android:textStyle="bold"
             app:layout_constraintBottom_toTopOf="@id/btn_storage"
             app:layout_constraintTop_toBottomOf="@id/tv_title" />
 

--- a/app/src/main/res/layout/fragment_add_challenge.xml
+++ b/app/src/main/res/layout/fragment_add_challenge.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:bind="http://schemas.android.com/tools">
 
     <data>
 
@@ -23,17 +23,16 @@
             android:textAppearance="@style/HeaderText"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <EditText
+        <include
             android:id="@+id/et_new_challenge"
-            style="@style/ChallengeInputCard"
+            layout="@layout/layout_input_card"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/space_large"
             android:layout_marginTop="@dimen/space_default"
-            android:importantForAutofill="no"
-            android:text="@={vm.input}"
             app:layout_constraintBottom_toTopOf="@id/btn_storage"
-            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            bind:input="@={vm.input}" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_storage"
@@ -46,32 +45,6 @@
             app:layout_constraintBottom_toTopOf="@id/btn_next"
             app:layout_constraintEnd_toEndOf="@id/et_new_challenge"
             app:layout_constraintTop_toBottomOf="@id/et_new_challenge" />
-
-        <TextView
-            android:id="@+id/tv_length"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="end"
-            android:text="@{String.valueOf(vm.input.length())}"
-            android:textColor="@color/cell_label"
-            android:textSize="@dimen/text_size_caption"
-            android:textStyle="bold"
-            app:layout_constraintBaseline_toBaselineOf="@id/tv_max"
-            app:layout_constraintEnd_toStartOf="@id/tv_max"
-            tools:text="3" />
-
-        <TextView
-            android:id="@+id/tv_max"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/space_default"
-            android:gravity="end"
-            android:text="/50"
-            android:textColor="@color/cell_label"
-            android:textSize="@dimen/text_size_caption"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="@id/et_new_challenge"
-            app:layout_constraintEnd_toEndOf="@id/et_new_challenge" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_next"

--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
@@ -59,7 +60,8 @@
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/space_default"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            tools:listitem="@layout/item_storage" />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/fab_add_storage"

--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/clear"
+            app:elevation="0dp">
+
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/tb_past_challenge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/space_default"
+                    android:gravity="center_vertical"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/space_text"
+                        android:text="@string/menu_title_storage"
+                        android:textAppearance="@style/HeaderText" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/storage_description"
+                        android:textColor="@color/secondary_label" />
+                </LinearLayout>
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <TextView
+            android:id="@+id/tv_empty_storage"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:drawablePadding="@dimen/space_default"
+            android:gravity="center"
+            android:text="@string/message_empty_storage"
+            android:textSize="@dimen/text_size_body2"
+            app:drawableTint="@color/dim"
+            app:drawableTopCompat="@drawable/ic_folder_off_48" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_past_challenge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/space_default"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_storage.xml
+++ b/app/src/main/res/layout/fragment_storage.xml
@@ -60,5 +60,14 @@
             android:paddingTop="@dimen/space_default"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fab_add_storage"
+            style="@style/Widget.App.FloatingActionButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/space_default"
+            android:src="@drawable/ic_add_24" />
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/item_storage.xml
+++ b/app/src/main/res/layout/item_storage.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/space_default"
+    android:layout_marginBottom="@dimen/space_default"
+    android:background="@drawable/bg_challenge_card"
+    android:padding="@dimen/space_default">
+
+    <TextView
+        android:id="@+id/tv_content"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/space_default"
+        android:ellipsize="end"
+        android:maxLines="3"
+        android:textColor="@color/secondary_label"
+        android:textSize="@dimen/text_size_body2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/ibt_delete"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@tools:sample/lorem/random" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/ibt_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:src="@drawable/ic_close_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/secondary_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_input_card.xml
+++ b/app/src/main/res/layout/layout_input_card.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="input"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <EditText
+            android:id="@+id/et_new_challenge"
+            style="@style/ChallengeInputCard"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:importantForAutofill="no"
+            android:text="@={input}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_length"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:text="@{String.valueOf(input.length())}"
+            android:textColor="@color/cell_label"
+            android:textSize="@dimen/text_size_caption"
+            android:textStyle="bold"
+            app:layout_constraintBaseline_toBaselineOf="@id/tv_max"
+            app:layout_constraintEnd_toStartOf="@id/tv_max"
+            tools:text="3" />
+
+        <TextView
+            android:id="@+id/tv_max"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/space_default"
+            android:gravity="end"
+            android:text="/50"
+            android:textColor="@color/cell_label"
+            android:textSize="@dimen/text_size_caption"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/et_new_challenge"
+            app:layout_constraintEnd_toEndOf="@id/et_new_challenge" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/app/src/main/res/menu/menu_bottom_nav.xml
@@ -11,6 +11,6 @@
 
     <item
         android:id="@+id/menu_storage"
-        android:icon="@drawable/ic_inventory_2_24"
+        android:icon="@drawable/selector_storage"
         android:title="@string/menu_title_storage" />
 </menu>

--- a/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/app/src/main/res/menu/menu_bottom_nav.xml
@@ -8,4 +8,9 @@
         android:id="@+id/menu_past_challenge"
         android:icon="@drawable/ic_list_alt_24"
         android:title="@string/menu_title_past_challenge" />
+
+    <item
+        android:id="@+id/menu_storage"
+        android:icon="@drawable/ic_inventory_2_24"
+        android:title="@string/menu_title_storage" />
 </menu>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -48,7 +48,7 @@
     <string name="today_widget_description">오늘의 챌린지를 확인합니다.</string>
     <string name="today_widget_placeholder">오늘의 챌린지를 등록하세요!</string>
     <string name="today_widget_title">오늘의 챌린지</string>
-    <string name="menu_title_storage">바구니</string>
+    <string name="menu_title_storage">챌린지 바구니</string>
     <string name="message_empty_storage">바구니에 챌린지가\n없어요</string>
     <string name="storage_description">챌린지를 담아두고 매일 편하게 오늘의 챌린지로 등록하세요</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -49,4 +49,6 @@
     <string name="today_widget_placeholder">오늘의 챌린지를 등록하세요!</string>
     <string name="today_widget_title">오늘의 챌린지</string>
     <string name="menu_title_storage">바구니</string>
+    <string name="message_empty_storage">바구니에 챌린지가\n없어요</string>
+    <string name="storage_description">챌린지를 담아두고 매일 편하게 오늘의 챌린지로 등록하세요</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -48,4 +48,5 @@
     <string name="today_widget_description">오늘의 챌린지를 확인합니다.</string>
     <string name="today_widget_placeholder">오늘의 챌린지를 등록하세요!</string>
     <string name="today_widget_title">오늘의 챌린지</string>
+    <string name="menu_title_storage">바구니</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="space_default">20dp</dimen>
+    <dimen name="space_default">16dp</dimen>
+    <dimen name="space_small">8dp</dimen>
     <dimen name="space_medium">35dp</dimen>
     <dimen name="space_large">40dp</dimen>
     <dimen name="space_text">5dp</dimen>
     <dimen name="radius_default">16dp</dimen>
     <dimen name="radius_button">50dp</dimen>
-    <dimen name="text_size_heading">25sp</dimen>
+    <dimen name="text_size_heading">22sp</dimen>
     <dimen name="text_size_body1">18sp</dimen>
     <dimen name="text_size_body2">16sp</dimen>
     <dimen name="text_size_caption">12sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,6 @@
     <string name="today_widget_title">Challenge of the day</string>
     <string name="today_widget_description">Check challenge of the day</string>
     <string name="today_widget_placeholder">Add challenge of the day!</string>
+    <string name="message_empty_storage">바구니에 챌린지가\n없어요</string>
+    <string name="storage_description">챌린지를 담아두고 매일 편하게 오늘의 챌린지로 등록하세요</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="menu_title_today">Today</string>
     <string name="title_today">Challenge of the Day</string>
     <string name="menu_title_past_challenge">Achievements</string>
+    <string name="menu_title_storage">Storage</string>
     <string name="setting">Settings</string>
     <string name="message_no_challenge">There’s no today’s challenge yet</string>
     <string name="button_add_challenge">Add</string>

--- a/app/src/main/res/values/style_button.xml
+++ b/app/src/main/res/values/style_button.xml
@@ -17,4 +17,14 @@
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
     </style>
+
+    <style name="IconTextButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:backgroundTint">@color/cell_fill</item>
+        <item name="android:textColor">@color/cell_label</item>
+        <item name="android:textSize">@dimen/text_size_body2</item>
+        <item name="android:paddingHorizontal">@dimen/space_default</item>
+        <item name="android:paddingVertical">@dimen/space_small</item>
+        <item name="cornerRadius">8dp</item>
+        <item name="iconTint">@color/cell_label</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -38,4 +38,13 @@
         <item name="appWidgetPadding">16dp</item>
     </style>
 
+    <style name="Widget.App.FloatingActionButton" parent="Widget.MaterialComponents.FloatingActionButton">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.FloatingActionButton</item>
+    </style>
+
+    <style name="ThemeOverlay.App.FloatingActionButton" parent="">
+        <item name="colorSecondary">@color/red_02</item>
+        <item name="colorOnSecondary">@color/white</item>
+        <item name="colorOnSurface">@color/white</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -48,13 +48,16 @@
         <item name="colorOnSurface">@color/white</item>
     </style>
 
-    <style name="IconTextButton" parent="Widget.MaterialComponents.Button.TextButton">
-        <item name="android:backgroundTint">@color/cell_fill</item>
+    <style name="ChallengeInputCard" parent="Widget.AppCompat.EditText">
+        <item name="android:background">@drawable/bg_challenge_card</item>
+        <item name="android:gravity">center</item>
+        <item name="android:hint">@string/hint_for_challenge</item>
+        <item name="android:inputType">textMultiLine</item>
+        <item name="android:maxLength">50</item>
+        <item name="android:paddingHorizontal">@dimen/space_large</item>
+        <item name="android:paddingVertical">@dimen/space_default</item>
         <item name="android:textColor">@color/cell_label</item>
         <item name="android:textSize">@dimen/text_size_body2</item>
-        <item name="android:paddingHorizontal">@dimen/space_default</item>
-        <item name="android:paddingVertical">@dimen/space_small</item>
-        <item name="cornerRadius">8dp</item>
-        <item name="iconTint">@color/cell_label</item>
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -47,4 +47,14 @@
         <item name="colorOnSecondary">@color/white</item>
         <item name="colorOnSurface">@color/white</item>
     </style>
+
+    <style name="IconTextButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:backgroundTint">@color/cell_fill</item>
+        <item name="android:textColor">@color/cell_label</item>
+        <item name="android:textSize">@dimen/text_size_body2</item>
+        <item name="android:paddingHorizontal">@dimen/space_default</item>
+        <item name="android:paddingVertical">@dimen/space_small</item>
+        <item name="cornerRadius">8dp</item>
+        <item name="iconTint">@color/cell_label</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- close #67 

## 주요 구현 사항
- 하단 메뉴에 챌린지 바구니가 생겼습니다
    - 아이콘은 selector로 선택된 상태에 맞게 드로어블을 사용합니다
- 등록/수정 화면 하단에 바구니 버튼이 추가되었습니다
   - 기존에는 피그마에서 iOS 수치를 그대로 가져다 썼는데 `바구니` 버튼이 추가되니 뷰가 많이 옹졸(...)해져서 전체적으로 텍스트와 여백 사이즈를 조정했습니다
- 챌린지 인풋 카드 뷰를 여기저기서 재사용하고 싶어서 레이아웃으로 따로 분리했습니다
   - 아예 프래그먼트를 재사용할까 했지만,, 뷰모델을 분기처리하는게 더 이상할 것 같아서 따로 만들기로 했습니다
 
## TODO
- 인풋 텍스트가 길이 영역을 침범해서 clear 버튼과 겹쳐지는 문제가 발생하여 clear 버튼은 우선은 추가하지 않았습니다..

## 스크린샷
<p>
<img src="https://user-images.githubusercontent.com/78132126/218704936-2c230fa8-b9d6-43ad-9c73-0d9f24cc1727.png" width="300" />
<img src="https://user-images.githubusercontent.com/78132126/218705007-249b6938-0167-4dae-a3dd-449bcdcd4aa2.png" width="300" />
</p>
