### PR TITLE
[REFACTOR] savedStateHandle 도입

### DIFF
--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeFragment.kt
@@ -10,24 +10,16 @@ import androidx.fragment.app.viewModels
 import com.hrhn.R
 import com.hrhn.databinding.FragmentAddChallengeBinding
 import com.hrhn.domain.model.Challenge
-import com.hrhn.presentation.util.customGetSerializable
 import com.hrhn.presentation.util.observeEvent
 import com.hrhn.presentation.util.showToast
 import com.hrhn.presentation.widget.TodayChallengeWidgetProvider
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class AddChallengeFragment : Fragment() {
     private var _binding: FragmentAddChallengeBinding? = null
     private val binding get() = requireNotNull(_binding)
-    private val data by lazy { requireArguments().customGetSerializable(KEY_CHALLENGE) as Challenge? }
-
-    @Inject
-    lateinit var addEditChallengeViewModelFactory: AddEditChallengeViewModelFactory
-    private val viewModel: AddChallengeViewModel by viewModels {
-        AddChallengeViewModel.provideFactory(addEditChallengeViewModelFactory, data!!)
-    }
+    private val viewModel: AddChallengeViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/addchallenge/add/AddChallengeViewModel.kt
@@ -5,20 +5,22 @@ import com.hrhn.domain.model.Challenge
 import com.hrhn.domain.repository.ChallengeRepository
 import com.hrhn.presentation.util.Event
 import com.hrhn.presentation.util.emit
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class AddChallengeViewModel @AssistedInject constructor(
-    private val repository: ChallengeRepository,
-    @Assisted val challenge: Challenge
+@HiltViewModel
+class AddChallengeViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val repository: ChallengeRepository
 ) : ViewModel() {
     private val _navigateEvent = MutableLiveData<Event<Unit>>()
     val navigateEvent: LiveData<Event<Unit>> get() = _navigateEvent
 
     private val _message = MutableLiveData<Event<String>>()
     val message: LiveData<Event<String>> get() = _message
+
+    val challenge: Challenge get() = savedStateHandle[KEY_CHALLENGE] ?: Challenge()
 
     val input = MutableLiveData<String>(challenge.content)
     val nextEnabled: LiveData<Boolean> = Transformations.map(input) {
@@ -39,19 +41,6 @@ class AddChallengeViewModel @AssistedInject constructor(
     }
 
     companion object {
-        fun provideFactory(
-            assistedFactory: AddEditChallengeViewModelFactory,
-            challenge: Challenge
-        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return assistedFactory.create(challenge) as T
-            }
-        }
+        private const val KEY_CHALLENGE = "challenge"
     }
-}
-
-@AssistedFactory
-interface AddEditChallengeViewModelFactory {
-    fun create(challenge: Challenge): AddChallengeViewModel
 }

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/review/ReviewFragment.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/review/ReviewFragment.kt
@@ -13,23 +13,15 @@ import com.hrhn.R
 import com.hrhn.databinding.FragmentReviewBinding
 import com.hrhn.domain.model.Challenge
 import com.hrhn.presentation.ui.view.CheckEmojiAdapter
-import com.hrhn.presentation.util.customGetSerializable
 import com.hrhn.presentation.util.observeEvent
 import com.hrhn.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class ReviewFragment : Fragment() {
     private var _binding: FragmentReviewBinding? = null
     private val binding get() = requireNotNull(_binding)
-    private val data by lazy { requireArguments().customGetSerializable(KEY_CHALLENGE) as Challenge? }
-
-    @Inject
-    lateinit var reviewViewModelFactory: ReviewViewModelFactory
-    private val viewModel: ReviewViewModel by viewModels {
-        ReviewViewModel.provideFactory(reviewViewModelFactory, data!!)
-    }
+    private val viewModel: ReviewViewModel by viewModels()
     private val adapter by lazy { CheckEmojiAdapter { viewModel.checkedChanged(it) } }
 
     override fun onCreateView(

--- a/app/src/main/java/com/hrhn/presentation/ui/screen/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/hrhn/presentation/ui/screen/review/ReviewViewModel.kt
@@ -7,15 +7,15 @@ import com.hrhn.domain.repository.ChallengeRepository
 import com.hrhn.presentation.ui.view.CheckableEmoji
 import com.hrhn.presentation.util.Event
 import com.hrhn.presentation.util.emit
-import dagger.assisted.Assisted
-import dagger.assisted.AssistedFactory
-import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class ReviewViewModel @AssistedInject constructor(
-    private val repository: ChallengeRepository,
-    @Assisted val challenge: Challenge
+@HiltViewModel
+class ReviewViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val repository: ChallengeRepository
 ) : ViewModel() {
 
     private val _finishEvent = MutableLiveData<Event<Unit>>()
@@ -25,6 +25,8 @@ class ReviewViewModel @AssistedInject constructor(
     val message: LiveData<Event<String>> get() = _message
 
     private val _selected = MutableLiveData<Emoji?>()
+
+    val challenge: Challenge get() = savedStateHandle[KEY_CHALLENGE] ?: Challenge()
 
     private val _emojis = MutableLiveData(
         Emoji.values().map { CheckableEmoji(emoji = it, isChecked = challenge.emoji == it) }
@@ -48,19 +50,6 @@ class ReviewViewModel @AssistedInject constructor(
     }
 
     companion object {
-        fun provideFactory(
-            assistedFactory: ReviewViewModelFactory,
-            challenge: Challenge
-        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return assistedFactory.create(challenge) as T
-            }
-        }
+        private const val KEY_CHALLENGE = "challenge"
     }
-}
-
-@AssistedFactory
-interface ReviewViewModelFactory {
-    fun create(challenge: Challenge): ReviewViewModel
 }


### PR DESCRIPTION
## 관련 이슈
- close #72 

## 주요 내용
- 기존에는 받은 챌린지 데이터를 argument로 받아 꺼낸 다음, 뷰모델 팩토리에 인자로 넣어 뷰모델을 생성하는 방법을 사용했다.
- 하지만 savedStateHandle을 사용하면 Activity/Fragment에서 받은 argument를 뷰모델에서 접근하여 활용할 수 있어 Activity/Fragment에서 받은 데이터를 꺼내 다시 넣어줄 필요가 없어진다.
- Fragment 1.2.0 또는Activity 1.1.0부터는 SavedStateHandle를 ViewModel의 생성자 인수로 사용 가능하기 때문에 따로 팩토리를 만들지 않아도 무방하다.
